### PR TITLE
zzzzsb / 4주차 / 4문제 

### DIFF
--- a/zzzzsb/boj_11047.js
+++ b/zzzzsb/boj_11047.js
@@ -1,0 +1,12 @@
+const input = require("fs").readFileSync("/dev/stdin").toString().trim().split("\n");
+const [N, K] = input.shift().split(" ").map(v => Number(v));
+const coins = input.map(v => Number(v)).filter(v => v <= K).reverse();
+let count = 0;
+let remain = K;
+for(let coin of coins){
+    if(remain == 0) break;
+    count += Math.floor(remain/coin);
+    remain %= coin;
+}
+
+console.log(count);

--- a/zzzzsb/boj_11399.js
+++ b/zzzzsb/boj_11399.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const filePath = process.platform === "linux" ? "/dev/stdin" : "./input.txt";
+let input = fs.readFileSync(filePath).toString().trim().split("\n");
+const nums = input[1].split(" ").map(Number);
+/*
+3 1 4 3 2
+-> 오름차순 정렬
+1 2 3 3 4
+1 3 6 9 13
+2번: 1분
+5번: 1+2=3분
+1번: 1+2+3=6분
+4번: 1+2+3+3=9분
+3번: 1+2+3+3+4 = 13분
+
+1+3+6+9+13 = 32분
+*/
+nums.sort((a,b) => a-b);
+let sum = 0;
+let wait= 0;
+for(let i=0; i<nums.length; i++){
+    wait += nums[i];
+    sum += wait;
+}
+console.log(sum);

--- a/zzzzsb/boj_1912.js
+++ b/zzzzsb/boj_1912.js
@@ -1,0 +1,20 @@
+/*
+nums 10, -4, 3, 1, 5, 6, -35, 12, 21, -1 
+dp   10  6   9 10 15  21  -14 12  33  32
+현재까지 더한값과 지금 값 비교
+*/
+const input = require("fs").readFileSync("/dev/stdin").toString().trim().split("\n");
+const n = Number(input[0]);
+const nums = input[1].split(" ").map(v => Number(v));
+const dp = new Array(n).fill(0);
+let max = 0;
+
+dp[0] = nums[0];
+max = dp[0];
+
+for(let i=1; i<nums.length; i++){
+    dp[i] = Math.max(dp[i-1]+nums[i], nums[i]);
+    max = Math.max(max, dp[i]);
+}
+
+console.log(max);

--- a/zzzzsb/pgs_H-Index.js
+++ b/zzzzsb/pgs_H-Index.js
@@ -1,0 +1,9 @@
+function solution(citations) {
+  let h_index = 0;
+  citations.sort((a,b) => b-a);
+  while(h_index+1 <= citations[h_index]){
+      h_index++;
+  }
+
+  return h_index;
+}


### PR DESCRIPTION
# 📝 4주차 리뷰
## 📍탐욕법
### [BOJ] 동전 0
주어진 금액보다 적은 동전은 제외하고, 역순으로 배치한 coins 배열을 만들어준다.
(예제에서 4200원 -> [1000, 500, 100, 50, 10, 5, 1] 로 만들어줌)
금액과 동전을 나눠준 몫이 동전 개수가 되기 때문에, for문으로 해당 계산을 반복하며 count에 더해준다. 나머지값은 다음 반복문에서 나눠질 금액값이 된다.

## 📍정렬
### [PGS] H-Index
인용횟수 배열(citations)을 내림차순 정렬해주고, 인용횟수와 논문수가 같아지는 지점을 구하면 된다. 

### [BOJ] ATM
인출시간이 가장 짧은 순서대로 줄을 섰을때가 최소 시간이 소요되므로, 인출시간을 오름차순 정렬 해준후 누적 대기시간을 구해 더해주면 된다.

## 📍동적계획법
### [BOJ] 연속합
이전 연속합과 현재 내 값을 더한값과, 현재 내 값을 비교했을때 더 큰 값이 가장 큰 연속합이 된다. 이 로직으로 dp배열을 구현해주고 가장 큰 합을 갱신해주면 된다.
